### PR TITLE
Support API when `CancellationToken` is not present

### DIFF
--- a/src/Immediate.Apis.Generators/ImmediateApisGenerator.Transform.cs
+++ b/src/Immediate.Apis.Generators/ImmediateApisGenerator.Transform.cs
@@ -63,10 +63,22 @@ public sealed partial class ImmediateApisGenerator
 
 		var @namespace = symbol.ContainingNamespace.ToString().NullIf("<global namespace>");
 		var @class = GetClass(symbol);
+
+		token.ThrowIfCancellationRequested();
+
 		var className = symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+
+		token.ThrowIfCancellationRequested();
+
 		var classAsMethodName = symbol.ToString().Replace(".", "_");
+
+		token.ThrowIfCancellationRequested();
+
 		var parameterType = handleMethod.Parameters[0].Type;
 		var mapMethod = GetMapMethod(attribute);
+
+		token.ThrowIfCancellationRequested();
+
 		var httpMethod = GetHttpMethod(attribute);
 
 		token.ThrowIfCancellationRequested();
@@ -125,8 +137,8 @@ public sealed partial class ImmediateApisGenerator
 			return null;
 		}
 
-		// must have request type and cancellation token
-		if (handleMethod.Parameters.Length < 2)
+		// must have request type
+		if (handleMethod.Parameters.Length is 0)
 			return null;
 
 		return handleMethod;

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Delete#IH.Dummy.GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Delete#IH.Dummy.GetUsersQuery.g.verified.cs
@@ -1,0 +1,68 @@
+﻿//HintName: IH.Dummy.GetUsersQuery.g.cs
+using Microsoft.Extensions.DependencyInjection;
+
+#pragma warning disable CS1591
+
+namespace Dummy;
+
+partial class GetUsersQuery
+{
+	public sealed partial class Handler : global::Immediate.Handlers.Shared.IHandler<global::Dummy.GetUsersQuery.Query, int>
+	{
+		private readonly global::Dummy.GetUsersQuery.HandleBehavior _handleBehavior;
+
+		public Handler(
+			global::Dummy.GetUsersQuery.HandleBehavior handleBehavior
+		)
+		{
+			var handlerType = typeof(GetUsersQuery);
+
+			_handleBehavior = handleBehavior;
+
+		}
+
+		public async global::System.Threading.Tasks.ValueTask<int> HandleAsync(
+			global::Dummy.GetUsersQuery.Query request,
+			global::System.Threading.CancellationToken cancellationToken = default
+		)
+		{
+			return await _handleBehavior
+				.HandleAsync(request, cancellationToken)
+				.ConfigureAwait(false);
+		}
+	}
+
+	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+	public sealed class HandleBehavior : global::Immediate.Handlers.Shared.Behavior<global::Dummy.GetUsersQuery.Query, int>
+	{
+
+		public HandleBehavior(
+		)
+		{
+		}
+
+		public override async global::System.Threading.Tasks.ValueTask<int> HandleAsync(
+			global::Dummy.GetUsersQuery.Query request,
+			global::System.Threading.CancellationToken cancellationToken
+		)
+		{
+			return await global::Dummy.GetUsersQuery
+				.Handle(
+					request
+				)
+				.ConfigureAwait(false);
+		}
+	}
+
+	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+	public static IServiceCollection AddHandlers(
+		IServiceCollection services,
+		ServiceLifetime lifetime = ServiceLifetime.Scoped
+	)
+	{
+		services.Add(new(typeof(global::Dummy.GetUsersQuery.Handler), typeof(global::Dummy.GetUsersQuery.Handler), lifetime));
+		services.Add(new(typeof(global::Immediate.Handlers.Shared.IHandler<global::Dummy.GetUsersQuery.Query, int>), typeof(global::Dummy.GetUsersQuery.Handler), lifetime));
+		services.Add(new(typeof(global::Dummy.GetUsersQuery.HandleBehavior), typeof(global::Dummy.GetUsersQuery.HandleBehavior), lifetime));
+		return services;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Delete#IH.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Delete#IH.ServiceCollectionExtensions.g.verified.cs
@@ -1,0 +1,25 @@
+﻿//HintName: IH.ServiceCollectionExtensions.g.cs
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+#pragma warning disable CS1591
+
+public static class HandlerServiceCollectionExtensions
+{
+	public static IServiceCollection AddTestsBehaviors(
+		this IServiceCollection services)
+	{
+		
+		return services;
+	}
+
+	public static IServiceCollection AddTestsHandlers(
+		this IServiceCollection services,
+		ServiceLifetime lifetime = ServiceLifetime.Scoped
+	)
+	{
+		global::Dummy.GetUsersQuery.AddHandlers(services, lifetime);
+		
+		return services;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,37 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using System.Threading;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder
+{
+	public static partial class TestsRoutesBuilder
+	{
+		private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+		{
+			var endpoint = app
+				.MapDelete(
+					"/test",
+					async (
+						[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+						[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+						CancellationToken token
+					) =>
+					{
+						var ret = await handler.HandleAsync(parameters, token);
+						return ret;
+					}
+				);
+		}
+	}
+}
+
+namespace Dummy
+{
+
+	/// <remarks><see cref="global::Dummy.GetUsersQuery.Query" /> registered using <c>[AsParameters]</c></remarks>
+	partial class GetUsersQuery;
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Delete#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Delete#RoutesBuilder.g.verified.cs
@@ -1,0 +1,19 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Get#IH.Dummy.GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Get#IH.Dummy.GetUsersQuery.g.verified.cs
@@ -1,0 +1,68 @@
+﻿//HintName: IH.Dummy.GetUsersQuery.g.cs
+using Microsoft.Extensions.DependencyInjection;
+
+#pragma warning disable CS1591
+
+namespace Dummy;
+
+partial class GetUsersQuery
+{
+	public sealed partial class Handler : global::Immediate.Handlers.Shared.IHandler<global::Dummy.GetUsersQuery.Query, int>
+	{
+		private readonly global::Dummy.GetUsersQuery.HandleBehavior _handleBehavior;
+
+		public Handler(
+			global::Dummy.GetUsersQuery.HandleBehavior handleBehavior
+		)
+		{
+			var handlerType = typeof(GetUsersQuery);
+
+			_handleBehavior = handleBehavior;
+
+		}
+
+		public async global::System.Threading.Tasks.ValueTask<int> HandleAsync(
+			global::Dummy.GetUsersQuery.Query request,
+			global::System.Threading.CancellationToken cancellationToken = default
+		)
+		{
+			return await _handleBehavior
+				.HandleAsync(request, cancellationToken)
+				.ConfigureAwait(false);
+		}
+	}
+
+	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+	public sealed class HandleBehavior : global::Immediate.Handlers.Shared.Behavior<global::Dummy.GetUsersQuery.Query, int>
+	{
+
+		public HandleBehavior(
+		)
+		{
+		}
+
+		public override async global::System.Threading.Tasks.ValueTask<int> HandleAsync(
+			global::Dummy.GetUsersQuery.Query request,
+			global::System.Threading.CancellationToken cancellationToken
+		)
+		{
+			return await global::Dummy.GetUsersQuery
+				.Handle(
+					request
+				)
+				.ConfigureAwait(false);
+		}
+	}
+
+	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+	public static IServiceCollection AddHandlers(
+		IServiceCollection services,
+		ServiceLifetime lifetime = ServiceLifetime.Scoped
+	)
+	{
+		services.Add(new(typeof(global::Dummy.GetUsersQuery.Handler), typeof(global::Dummy.GetUsersQuery.Handler), lifetime));
+		services.Add(new(typeof(global::Immediate.Handlers.Shared.IHandler<global::Dummy.GetUsersQuery.Query, int>), typeof(global::Dummy.GetUsersQuery.Handler), lifetime));
+		services.Add(new(typeof(global::Dummy.GetUsersQuery.HandleBehavior), typeof(global::Dummy.GetUsersQuery.HandleBehavior), lifetime));
+		return services;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Get#IH.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Get#IH.ServiceCollectionExtensions.g.verified.cs
@@ -1,0 +1,25 @@
+﻿//HintName: IH.ServiceCollectionExtensions.g.cs
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+#pragma warning disable CS1591
+
+public static class HandlerServiceCollectionExtensions
+{
+	public static IServiceCollection AddTestsBehaviors(
+		this IServiceCollection services)
+	{
+		
+		return services;
+	}
+
+	public static IServiceCollection AddTestsHandlers(
+		this IServiceCollection services,
+		ServiceLifetime lifetime = ServiceLifetime.Scoped
+	)
+	{
+		global::Dummy.GetUsersQuery.AddHandlers(services, lifetime);
+		
+		return services;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,37 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using System.Threading;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder
+{
+	public static partial class TestsRoutesBuilder
+	{
+		private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+		{
+			var endpoint = app
+				.MapGet(
+					"/test",
+					async (
+						[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+						[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+						CancellationToken token
+					) =>
+					{
+						var ret = await handler.HandleAsync(parameters, token);
+						return ret;
+					}
+				);
+		}
+	}
+}
+
+namespace Dummy
+{
+
+	/// <remarks><see cref="global::Dummy.GetUsersQuery.Query" /> registered using <c>[AsParameters]</c></remarks>
+	partial class GetUsersQuery;
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Get#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Get#RoutesBuilder.g.verified.cs
@@ -1,0 +1,19 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Patch#IH.Dummy.GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Patch#IH.Dummy.GetUsersQuery.g.verified.cs
@@ -1,0 +1,68 @@
+﻿//HintName: IH.Dummy.GetUsersQuery.g.cs
+using Microsoft.Extensions.DependencyInjection;
+
+#pragma warning disable CS1591
+
+namespace Dummy;
+
+partial class GetUsersQuery
+{
+	public sealed partial class Handler : global::Immediate.Handlers.Shared.IHandler<global::Dummy.GetUsersQuery.Query, int>
+	{
+		private readonly global::Dummy.GetUsersQuery.HandleBehavior _handleBehavior;
+
+		public Handler(
+			global::Dummy.GetUsersQuery.HandleBehavior handleBehavior
+		)
+		{
+			var handlerType = typeof(GetUsersQuery);
+
+			_handleBehavior = handleBehavior;
+
+		}
+
+		public async global::System.Threading.Tasks.ValueTask<int> HandleAsync(
+			global::Dummy.GetUsersQuery.Query request,
+			global::System.Threading.CancellationToken cancellationToken = default
+		)
+		{
+			return await _handleBehavior
+				.HandleAsync(request, cancellationToken)
+				.ConfigureAwait(false);
+		}
+	}
+
+	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+	public sealed class HandleBehavior : global::Immediate.Handlers.Shared.Behavior<global::Dummy.GetUsersQuery.Query, int>
+	{
+
+		public HandleBehavior(
+		)
+		{
+		}
+
+		public override async global::System.Threading.Tasks.ValueTask<int> HandleAsync(
+			global::Dummy.GetUsersQuery.Query request,
+			global::System.Threading.CancellationToken cancellationToken
+		)
+		{
+			return await global::Dummy.GetUsersQuery
+				.Handle(
+					request
+				)
+				.ConfigureAwait(false);
+		}
+	}
+
+	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+	public static IServiceCollection AddHandlers(
+		IServiceCollection services,
+		ServiceLifetime lifetime = ServiceLifetime.Scoped
+	)
+	{
+		services.Add(new(typeof(global::Dummy.GetUsersQuery.Handler), typeof(global::Dummy.GetUsersQuery.Handler), lifetime));
+		services.Add(new(typeof(global::Immediate.Handlers.Shared.IHandler<global::Dummy.GetUsersQuery.Query, int>), typeof(global::Dummy.GetUsersQuery.Handler), lifetime));
+		services.Add(new(typeof(global::Dummy.GetUsersQuery.HandleBehavior), typeof(global::Dummy.GetUsersQuery.HandleBehavior), lifetime));
+		return services;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Patch#IH.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Patch#IH.ServiceCollectionExtensions.g.verified.cs
@@ -1,0 +1,25 @@
+﻿//HintName: IH.ServiceCollectionExtensions.g.cs
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+#pragma warning disable CS1591
+
+public static class HandlerServiceCollectionExtensions
+{
+	public static IServiceCollection AddTestsBehaviors(
+		this IServiceCollection services)
+	{
+		
+		return services;
+	}
+
+	public static IServiceCollection AddTestsHandlers(
+		this IServiceCollection services,
+		ServiceLifetime lifetime = ServiceLifetime.Scoped
+	)
+	{
+		global::Dummy.GetUsersQuery.AddHandlers(services, lifetime);
+		
+		return services;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,37 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using System.Threading;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder
+{
+	public static partial class TestsRoutesBuilder
+	{
+		private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+		{
+			var endpoint = app
+				.MapPatch(
+					"/test",
+					async (
+						[FromBody] global::Dummy.GetUsersQuery.Query parameters,
+						[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+						CancellationToken token
+					) =>
+					{
+						var ret = await handler.HandleAsync(parameters, token);
+						return ret;
+					}
+				);
+		}
+	}
+}
+
+namespace Dummy
+{
+
+	/// <remarks><see cref="global::Dummy.GetUsersQuery.Query" /> registered using <c>[FromBody]</c></remarks>
+	partial class GetUsersQuery;
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Patch#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Patch#RoutesBuilder.g.verified.cs
@@ -1,0 +1,19 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Post#IH.Dummy.GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Post#IH.Dummy.GetUsersQuery.g.verified.cs
@@ -1,0 +1,68 @@
+﻿//HintName: IH.Dummy.GetUsersQuery.g.cs
+using Microsoft.Extensions.DependencyInjection;
+
+#pragma warning disable CS1591
+
+namespace Dummy;
+
+partial class GetUsersQuery
+{
+	public sealed partial class Handler : global::Immediate.Handlers.Shared.IHandler<global::Dummy.GetUsersQuery.Query, int>
+	{
+		private readonly global::Dummy.GetUsersQuery.HandleBehavior _handleBehavior;
+
+		public Handler(
+			global::Dummy.GetUsersQuery.HandleBehavior handleBehavior
+		)
+		{
+			var handlerType = typeof(GetUsersQuery);
+
+			_handleBehavior = handleBehavior;
+
+		}
+
+		public async global::System.Threading.Tasks.ValueTask<int> HandleAsync(
+			global::Dummy.GetUsersQuery.Query request,
+			global::System.Threading.CancellationToken cancellationToken = default
+		)
+		{
+			return await _handleBehavior
+				.HandleAsync(request, cancellationToken)
+				.ConfigureAwait(false);
+		}
+	}
+
+	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+	public sealed class HandleBehavior : global::Immediate.Handlers.Shared.Behavior<global::Dummy.GetUsersQuery.Query, int>
+	{
+
+		public HandleBehavior(
+		)
+		{
+		}
+
+		public override async global::System.Threading.Tasks.ValueTask<int> HandleAsync(
+			global::Dummy.GetUsersQuery.Query request,
+			global::System.Threading.CancellationToken cancellationToken
+		)
+		{
+			return await global::Dummy.GetUsersQuery
+				.Handle(
+					request
+				)
+				.ConfigureAwait(false);
+		}
+	}
+
+	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+	public static IServiceCollection AddHandlers(
+		IServiceCollection services,
+		ServiceLifetime lifetime = ServiceLifetime.Scoped
+	)
+	{
+		services.Add(new(typeof(global::Dummy.GetUsersQuery.Handler), typeof(global::Dummy.GetUsersQuery.Handler), lifetime));
+		services.Add(new(typeof(global::Immediate.Handlers.Shared.IHandler<global::Dummy.GetUsersQuery.Query, int>), typeof(global::Dummy.GetUsersQuery.Handler), lifetime));
+		services.Add(new(typeof(global::Dummy.GetUsersQuery.HandleBehavior), typeof(global::Dummy.GetUsersQuery.HandleBehavior), lifetime));
+		return services;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Post#IH.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Post#IH.ServiceCollectionExtensions.g.verified.cs
@@ -1,0 +1,25 @@
+﻿//HintName: IH.ServiceCollectionExtensions.g.cs
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+#pragma warning disable CS1591
+
+public static class HandlerServiceCollectionExtensions
+{
+	public static IServiceCollection AddTestsBehaviors(
+		this IServiceCollection services)
+	{
+		
+		return services;
+	}
+
+	public static IServiceCollection AddTestsHandlers(
+		this IServiceCollection services,
+		ServiceLifetime lifetime = ServiceLifetime.Scoped
+	)
+	{
+		global::Dummy.GetUsersQuery.AddHandlers(services, lifetime);
+		
+		return services;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,37 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using System.Threading;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder
+{
+	public static partial class TestsRoutesBuilder
+	{
+		private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+		{
+			var endpoint = app
+				.MapPost(
+					"/test",
+					async (
+						[FromBody] global::Dummy.GetUsersQuery.Query parameters,
+						[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+						CancellationToken token
+					) =>
+					{
+						var ret = await handler.HandleAsync(parameters, token);
+						return ret;
+					}
+				);
+		}
+	}
+}
+
+namespace Dummy
+{
+
+	/// <remarks><see cref="global::Dummy.GetUsersQuery.Query" /> registered using <c>[FromBody]</c></remarks>
+	partial class GetUsersQuery;
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Post#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Post#RoutesBuilder.g.verified.cs
@@ -1,0 +1,19 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Put#IH.Dummy.GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Put#IH.Dummy.GetUsersQuery.g.verified.cs
@@ -1,0 +1,68 @@
+﻿//HintName: IH.Dummy.GetUsersQuery.g.cs
+using Microsoft.Extensions.DependencyInjection;
+
+#pragma warning disable CS1591
+
+namespace Dummy;
+
+partial class GetUsersQuery
+{
+	public sealed partial class Handler : global::Immediate.Handlers.Shared.IHandler<global::Dummy.GetUsersQuery.Query, int>
+	{
+		private readonly global::Dummy.GetUsersQuery.HandleBehavior _handleBehavior;
+
+		public Handler(
+			global::Dummy.GetUsersQuery.HandleBehavior handleBehavior
+		)
+		{
+			var handlerType = typeof(GetUsersQuery);
+
+			_handleBehavior = handleBehavior;
+
+		}
+
+		public async global::System.Threading.Tasks.ValueTask<int> HandleAsync(
+			global::Dummy.GetUsersQuery.Query request,
+			global::System.Threading.CancellationToken cancellationToken = default
+		)
+		{
+			return await _handleBehavior
+				.HandleAsync(request, cancellationToken)
+				.ConfigureAwait(false);
+		}
+	}
+
+	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+	public sealed class HandleBehavior : global::Immediate.Handlers.Shared.Behavior<global::Dummy.GetUsersQuery.Query, int>
+	{
+
+		public HandleBehavior(
+		)
+		{
+		}
+
+		public override async global::System.Threading.Tasks.ValueTask<int> HandleAsync(
+			global::Dummy.GetUsersQuery.Query request,
+			global::System.Threading.CancellationToken cancellationToken
+		)
+		{
+			return await global::Dummy.GetUsersQuery
+				.Handle(
+					request
+				)
+				.ConfigureAwait(false);
+		}
+	}
+
+	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+	public static IServiceCollection AddHandlers(
+		IServiceCollection services,
+		ServiceLifetime lifetime = ServiceLifetime.Scoped
+	)
+	{
+		services.Add(new(typeof(global::Dummy.GetUsersQuery.Handler), typeof(global::Dummy.GetUsersQuery.Handler), lifetime));
+		services.Add(new(typeof(global::Immediate.Handlers.Shared.IHandler<global::Dummy.GetUsersQuery.Query, int>), typeof(global::Dummy.GetUsersQuery.Handler), lifetime));
+		services.Add(new(typeof(global::Dummy.GetUsersQuery.HandleBehavior), typeof(global::Dummy.GetUsersQuery.HandleBehavior), lifetime));
+		return services;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Put#IH.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Put#IH.ServiceCollectionExtensions.g.verified.cs
@@ -1,0 +1,25 @@
+﻿//HintName: IH.ServiceCollectionExtensions.g.cs
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+#pragma warning disable CS1591
+
+public static class HandlerServiceCollectionExtensions
+{
+	public static IServiceCollection AddTestsBehaviors(
+		this IServiceCollection services)
+	{
+		
+		return services;
+	}
+
+	public static IServiceCollection AddTestsHandlers(
+		this IServiceCollection services,
+		ServiceLifetime lifetime = ServiceLifetime.Scoped
+	)
+	{
+		global::Dummy.GetUsersQuery.AddHandlers(services, lifetime);
+		
+		return services;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,37 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using System.Threading;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder
+{
+	public static partial class TestsRoutesBuilder
+	{
+		private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+		{
+			var endpoint = app
+				.MapPut(
+					"/test",
+					async (
+						[FromBody] global::Dummy.GetUsersQuery.Query parameters,
+						[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+						CancellationToken token
+					) =>
+					{
+						var ret = await handler.HandleAsync(parameters, token);
+						return ret;
+					}
+				);
+		}
+	}
+}
+
+namespace Dummy
+{
+
+	/// <remarks><see cref="global::Dummy.GetUsersQuery.Query" /> registered using <c>[FromBody]</c></remarks>
+	partial class GetUsersQuery;
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Put#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodMissingCancellationToken_method=Put#RoutesBuilder.g.verified.cs
@@ -1,0 +1,19 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.cs
@@ -220,4 +220,45 @@ public sealed class SimpleApiTests
 
 		_ = await Verify(result);
 	}
+
+	[Test]
+	[MethodDataSource(typeof(Utility), nameof(Utility.Methods))]
+	public async Task MapMethodMissingCancellationToken(string method)
+	{
+		var result = GeneratorTestHelper.RunGenerator(
+			$$"""
+			using System.Threading;
+			using System.Threading.Tasks;
+			using Immediate.Apis.Shared;
+			using Immediate.Handlers.Shared;
+			
+			namespace Dummy;
+
+			[Handler]
+			[Map{{method}}("/test")]
+			public static partial class GetUsersQuery
+			{
+				public record Query;
+
+				private static ValueTask<int> Handle(
+					Query _
+				)
+				{
+					return ValueTask.FromResult(0);
+				}
+			}
+			""");
+
+		Assert.Equal(
+			[
+				@"Immediate.Apis.Generators/Immediate.Apis.Generators.ImmediateApisGenerator/RouteBuilder.Dummy_GetUsersQuery.g.cs",
+				@"Immediate.Apis.Generators/Immediate.Apis.Generators.ImmediateApisGenerator/RoutesBuilder.g.cs",
+				@"Immediate.Handlers.Generators/Immediate.Handlers.Generators.ImmediateHandlers.ImmediateHandlersGenerator/IH.Dummy.GetUsersQuery.g.cs",
+				@"Immediate.Handlers.Generators/Immediate.Handlers.Generators.ImmediateHandlers.ImmediateHandlersGenerator/IH.ServiceCollectionExtensions.g.cs",
+			],
+			result.GeneratedTrees.Select(t => t.FilePath.Replace('\\', '/'))
+		);
+
+		_ = await Verify(result).UseParameters(method);
+	}
 }


### PR DESCRIPTION
Fixes #158 