### PR TITLE
Make route group prefix optional

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -205,11 +205,4 @@ app.MapApplicationUserManagementEndpoints("/users")
 	.RequireAuthorization(Policies.UserManagement);
 ```
 
-The route prefix argument is optional and defaults to an empty string, so you can omit it and specify the full route on each handler instead:
-
-```cs
-app.MapApplicationUserManagementEndpoints()
-	.RequireAuthorization(Policies.UserManagement);
-```
-
 Endpoints decorated with this attribute will no longer be mapped by the `MapApplicationEndpoints()` method.

--- a/readme.md
+++ b/readme.md
@@ -205,4 +205,11 @@ app.MapApplicationUserManagementEndpoints("/users")
 	.RequireAuthorization(Policies.UserManagement);
 ```
 
+The route prefix argument is optional and defaults to an empty string, so you can omit it and specify the full route on each handler instead:
+
+```cs
+app.MapApplicationUserManagementEndpoints()
+	.RequireAuthorization(Policies.UserManagement);
+```
+
 Endpoints decorated with this attribute will no longer be mapped by the `MapApplicationEndpoints()` method.

--- a/src/Immediate.Apis.Generators/Templates/Routes.sbntxt
+++ b/src/Immediate.Apis.Generators/Templates/Routes.sbntxt
@@ -10,7 +10,7 @@ public static partial class {{ assembly }}RoutesBuilder
 {
 	public static RouteGroupBuilder Map{{ assembly }}{{ name }}Endpoints(
 		this IEndpointRouteBuilder app,
-		[StringSyntax("Route")] string prefix{{ if name == null }} = ""{{ end }}
+		[StringSyntax("Route")] string prefix = ""
 	)
 	{
 		var group = app.MapGroup(prefix);

--- a/tests/Immediate.Apis.Tests/GeneratorTests/RouteGroupTests.ValidRouteGroupTest_groupName=123TestGroup#RouteGroupBuilder.123TestGroup.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/RouteGroupTests.ValidRouteGroupTest_groupName=123TestGroup#RouteGroupBuilder.123TestGroup.g.verified.cs
@@ -11,7 +11,7 @@ public static partial class TestsRoutesBuilder
 {
 	public static RouteGroupBuilder MapTests123TestGroupEndpoints(
 		this IEndpointRouteBuilder app,
-		[StringSyntax("Route")] string prefix
+		[StringSyntax("Route")] string prefix = ""
 	)
 	{
 		var group = app.MapGroup(prefix);

--- a/tests/Immediate.Apis.Tests/GeneratorTests/RouteGroupTests.ValidRouteGroupTest_groupName=Test123Group#RouteGroupBuilder.Test123Group.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/RouteGroupTests.ValidRouteGroupTest_groupName=Test123Group#RouteGroupBuilder.Test123Group.g.verified.cs
@@ -11,7 +11,7 @@ public static partial class TestsRoutesBuilder
 {
 	public static RouteGroupBuilder MapTestsTest123GroupEndpoints(
 		this IEndpointRouteBuilder app,
-		[StringSyntax("Route")] string prefix
+		[StringSyntax("Route")] string prefix = ""
 	)
 	{
 		var group = app.MapGroup(prefix);

--- a/tests/Immediate.Apis.Tests/GeneratorTests/RouteGroupTests.ValidRouteGroupTest_groupName=Test_Group#RouteGroupBuilder.Test_Group.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/RouteGroupTests.ValidRouteGroupTest_groupName=Test_Group#RouteGroupBuilder.Test_Group.g.verified.cs
@@ -11,7 +11,7 @@ public static partial class TestsRoutesBuilder
 {
 	public static RouteGroupBuilder MapTestsTest_GroupEndpoints(
 		this IEndpointRouteBuilder app,
-		[StringSyntax("Route")] string prefix
+		[StringSyntax("Route")] string prefix = ""
 	)
 	{
 		var group = app.MapGroup(prefix);

--- a/tests/Immediate.Apis.Tests/GeneratorTests/RouteGroupTests.ValidRouteGroupTest_groupName=_TestGroup#RouteGroupBuilder._TestGroup.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/RouteGroupTests.ValidRouteGroupTest_groupName=_TestGroup#RouteGroupBuilder._TestGroup.g.verified.cs
@@ -11,7 +11,7 @@ public static partial class TestsRoutesBuilder
 {
 	public static RouteGroupBuilder MapTests_TestGroupEndpoints(
 		this IEndpointRouteBuilder app,
-		[StringSyntax("Route")] string prefix
+		[StringSyntax("Route")] string prefix = ""
 	)
 	{
 		var group = app.MapGroup(prefix);


### PR DESCRIPTION
## Summary

Makes the `prefix` argument of the generated route-group registration method optional.

When a handler is decorated with `[RouteGroup("Name")]`, the generator emits:

```cs
public static RouteGroupBuilder Map{Assembly}{Name}Endpoints(
    this IEndpointRouteBuilder app,
    [StringSyntax("Route")] string prefix)
```

Previously `prefix` was **required** for named groups — only the default assembly-level group (`Map{Assembly}Endpoints`) defaulted it to `""`. This forces callers to pass a prefix even when they'd rather put the full route on each handler, e.g.:

```cs
[Handler]
[MapGet("/monitor/assemblies")]
[RouteGroup("Monitor")]
internal static partial class AssembliesEndpoint { /* ... */ }

// today you must write:
app.MapApplicationMonitorEndpoints(string.Empty);
// now you can simply write:
app.MapApplicationMonitorEndpoints();
```

This change always defaults `prefix` to `""` so the argument is optional for named groups too.

## Backward compatibility

Fully backward-compatible — callers that pass a prefix continue to work unchanged; the prefix simply becomes optional.

## Changes

- `src/Immediate.Apis.Generators/Templates/Routes.sbntxt` — always default `prefix` to `""`.
- Regenerated the affected `RouteGroupTests` verified snapshots.
- `readme.md` — note that the prefix argument is optional.
