### PR TITLE
Add RoutesBuilderName attribute to override generated builder name

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,16 @@ In your `Program.cs`, add a call to `app.MapXxxEndpoints()`, where `Xxx` is the 
 * For a project named `Web`, it will be `app.MapWebEndpoints()`
 * For a project named `Application.Web`, it will be `app.MapApplicationWebEndpoints()`
 
+#### Customizing the generated builder name
+
+By default `Xxx` is derived from the assembly name (with `.` and spaces removed). To use a different name, apply the `RoutesBuilderName` attribute at the assembly level:
+
+```cs
+[assembly: Immediate.Apis.Shared.RoutesBuilderName("Api")]
+```
+
+This generates an `ApiRoutesBuilder` class with `app.MapApiEndpoints()` (and `app.MapApiXxxEndpoints()` for each route group), independent of the assembly name. The value must be a valid C# identifier.
+
 ### Customizing the endpoints
 #### AsParameters
 

--- a/src/Common/ITypeSymbolExtensions.cs
+++ b/src/Common/ITypeSymbolExtensions.cs
@@ -169,6 +169,14 @@ internal static class ITypeSymbolExtensions
 			ContainingNamespace.IsImmediateApisShared: true,
 		};
 
+	public static bool IsRoutesBuilderNameAttribute(this ITypeSymbol? typeSymbol) =>
+		typeSymbol is INamedTypeSymbol
+		{
+			Arity: 0,
+			Name: "RoutesBuilderNameAttribute",
+			ContainingNamespace.IsImmediateApisShared: true,
+		};
+
 	extension(INamespaceSymbol namespaceSymbol)
 	{
 		public bool IsImmediateApisShared =>

--- a/src/Common/RoutesBuilderNameUtility.cs
+++ b/src/Common/RoutesBuilderNameUtility.cs
@@ -1,0 +1,25 @@
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Immediate.Apis;
+
+internal static class RoutesBuilderNameUtility
+{
+	public static bool IsValidRoutesBuilderName(string? value)
+	{
+		if (string.IsNullOrWhiteSpace(value))
+			return false;
+
+		if (!SyntaxFacts.IsIdentifierStartCharacter(value![0]))
+			return false;
+
+		for (var i = 1; i < value.Length; i++)
+		{
+			if (!SyntaxFacts.IsIdentifierPartCharacter(value[i]))
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+}

--- a/src/Immediate.Apis.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Immediate.Apis.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,5 @@
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|--------------------
+IAPI0011 | ImmediateApis | Error | InvalidRoutesBuilderNameAnalyzer

--- a/src/Immediate.Apis.Analyzers/DiagnosticIds.cs
+++ b/src/Immediate.Apis.Analyzers/DiagnosticIds.cs
@@ -12,4 +12,5 @@ internal static class DiagnosticIds
 	public const string IAPI0008HandlerShouldNotDependOnEndpoint = "IAPI0008";
 	public const string IAPI0009EndpointHasBeenSpecifiedMultipleTimes = "IAPI0009";
 	public const string IAPI0010InvalidRouteGroupName = "IAPI0010";
+	public const string IAPI0011InvalidRoutesBuilderName = "IAPI0011";
 }

--- a/src/Immediate.Apis.Analyzers/InvalidRoutesBuilderNameAnalyzer.cs
+++ b/src/Immediate.Apis.Analyzers/InvalidRoutesBuilderNameAnalyzer.cs
@@ -1,0 +1,82 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Immediate.Apis.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class InvalidRoutesBuilderNameAnalyzer : DiagnosticAnalyzer
+{
+	public static readonly DiagnosticDescriptor InvalidRoutesBuilderName =
+		new(
+			id: DiagnosticIds.IAPI0011InvalidRoutesBuilderName,
+			title: "Invalid routes builder name",
+			messageFormat: "Routes builder name `{0}` is not a valid identifier",
+			category: "ImmediateApis",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true,
+			description: "Routes builder names must be non-null, non-empty, and a valid C# identifier (start with a letter or underscore, followed by letters, digits, or underscores)."
+		);
+
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+		ImmutableArray.Create(
+		[
+			InvalidRoutesBuilderName,
+		]);
+
+	public override void Initialize(AnalysisContext context)
+	{
+		if (context == null)
+			throw new ArgumentNullException(nameof(context));
+
+		context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+		context.EnableConcurrentExecution();
+
+		context.RegisterSyntaxNodeAction(AnalyzeAttribute, SyntaxKind.Attribute);
+	}
+
+	private static void AnalyzeAttribute(SyntaxNodeAnalysisContext context)
+	{
+		var token = context.CancellationToken;
+		token.ThrowIfCancellationRequested();
+
+		if (context.Node is not AttributeSyntax
+			{
+				Parent: AttributeListSyntax { Target.Identifier.RawKind: (int)SyntaxKind.AssemblyKeyword },
+				ArgumentList.Arguments: [{ Expression: var argumentExpression }, ..],
+			} attribute)
+		{
+			return;
+		}
+
+		token.ThrowIfCancellationRequested();
+
+		if (context.SemanticModel.GetSymbolInfo(attribute, token).Symbol?.ContainingType
+			is not { } attributeType
+			|| !attributeType.IsRoutesBuilderNameAttribute())
+		{
+			return;
+		}
+
+		token.ThrowIfCancellationRequested();
+
+		var value = context.SemanticModel.GetConstantValue(argumentExpression, token) is { HasValue: true, Value: string s }
+			? s
+			: null;
+
+		if (RoutesBuilderNameUtility.IsValidRoutesBuilderName(value))
+			return;
+
+		token.ThrowIfCancellationRequested();
+
+		context.ReportDiagnostic(
+			Diagnostic.Create(
+				InvalidRoutesBuilderName,
+				attribute.GetLocation(),
+				value
+			)
+		);
+	}
+}

--- a/src/Immediate.Apis.Generators/ImmediateApisGenerator.cs
+++ b/src/Immediate.Apis.Generators/ImmediateApisGenerator.cs
@@ -18,11 +18,21 @@ public sealed partial class ImmediateApisGenerator : IIncrementalGenerator
 			.WithTrackingName("Handlers");
 
 		var assemblyName = context.CompilationProvider
-			.Select((cp, _) => cp.AssemblyName!
-				.Replace(".", string.Empty)
-				.Replace(" ", string.Empty)
-				.Trim()
-			)
+			.Select((cp, _) =>
+			{
+				if (cp.Assembly.GetAttributes()
+						.FirstOrDefault(a => a.AttributeClass.IsRoutesBuilderNameAttribute())
+						is { ConstructorArguments: [{ Value: string configuredName }] }
+					&& RoutesBuilderNameUtility.IsValidRoutesBuilderName(configuredName))
+				{
+					return configuredName;
+				}
+
+				return cp.AssemblyName!
+					.Replace(".", string.Empty)
+					.Replace(" ", string.Empty)
+					.Trim();
+			})
 			.WithTrackingName("AssemblyName");
 
 		var perMethodTemplate = Utility.GetTemplate("Route");

--- a/src/Immediate.Apis.Shared/RoutesBuilderNameAttribute.cs
+++ b/src/Immediate.Apis.Shared/RoutesBuilderNameAttribute.cs
@@ -1,0 +1,19 @@
+namespace Immediate.Apis.Shared;
+
+/// <summary>
+///		Applied to an assembly to override the name used for the generated routes builder class
+///		(<c>{Name}RoutesBuilder</c>) and its <c>Map{Name}Endpoints</c> registration methods.
+/// </summary>
+/// <remarks>
+///		When not specified, the name defaults to the assembly name with <c>.</c> and spaces removed.
+///		The value must be a valid C# identifier.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Assembly)]
+public sealed class RoutesBuilderNameAttribute(string name) : Attribute
+{
+	/// <summary>
+	///		The name to use in place of the assembly name when generating the routes builder class
+	///		and its registration methods.
+	/// </summary>
+	public string Name { get; } = name;
+}

--- a/tests/Immediate.Apis.Tests/AnalyzerTests/InvalidRoutesBuilderNameTests.cs
+++ b/tests/Immediate.Apis.Tests/AnalyzerTests/InvalidRoutesBuilderNameTests.cs
@@ -1,0 +1,64 @@
+using Immediate.Apis.Analyzers;
+
+namespace Immediate.Apis.Tests.AnalyzerTests;
+
+public sealed class InvalidRoutesBuilderNameTests
+{
+	[Theory]
+	[MemberData(nameof(Utility.ValidRoutesBuilderNames), MemberType = typeof(Utility))]
+	public async Task ValidRoutesBuilderNamesShouldNotError(string name) =>
+		await AnalyzerTestHelpers.CreateAnalyzerTest<InvalidRoutesBuilderNameAnalyzer>(
+			$$"""
+			using System.Threading;
+			using System.Threading.Tasks;
+			using Immediate.Apis.Shared;
+			using Immediate.Handlers.Shared;
+
+			[assembly: RoutesBuilderName("{{name}}")]
+
+			namespace Dummy;
+
+			[Handler]
+			[MapGet("/test")]
+			public static partial class GetUsersQuery
+			{
+				public record Query;
+
+				private static ValueTask<int> Handle(
+					Query _,
+					CancellationToken token)
+				{
+					return ValueTask.FromResult(0);
+				}
+			}
+			""").RunAsync(TestContext.Current.CancellationToken);
+
+	[Theory]
+	[MemberData(nameof(Utility.InvalidRoutesBuilderNames), MemberType = typeof(Utility))]
+	public async Task InvalidRoutesBuilderNamesShouldError(string name) =>
+		await AnalyzerTestHelpers.CreateAnalyzerTest<InvalidRoutesBuilderNameAnalyzer>(
+			$$"""
+			using System.Threading;
+			using System.Threading.Tasks;
+			using Immediate.Apis.Shared;
+			using Immediate.Handlers.Shared;
+
+			[assembly: {|IAPI0011:RoutesBuilderName("{{name}}")|}]
+
+			namespace Dummy;
+
+			[Handler]
+			[MapGet("/test")]
+			public static partial class GetUsersQuery
+			{
+				public record Query;
+
+				private static ValueTask<int> Handle(
+					Query _,
+					CancellationToken token)
+				{
+					return ValueTask.FromResult(0);
+				}
+			}
+			""").RunAsync(TestContext.Current.CancellationToken);
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/RoutesBuilderNameTests.CustomRoutesBuilderNameTest#IH.Dummy.GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/RoutesBuilderNameTests.CustomRoutesBuilderNameTest#IH.Dummy.GetUsersQuery.g.verified.cs
@@ -1,0 +1,69 @@
+﻿//HintName: IH.Dummy.GetUsersQuery.g.cs
+using Microsoft.Extensions.DependencyInjection;
+
+#pragma warning disable CS1591
+
+namespace Dummy;
+
+partial class GetUsersQuery
+{
+	public sealed partial class Handler : global::Immediate.Handlers.Shared.IHandler<global::Dummy.GetUsersQuery.Query, int>
+	{
+		private readonly global::Dummy.GetUsersQuery.HandleBehavior _handleBehavior;
+
+		public Handler(
+			global::Dummy.GetUsersQuery.HandleBehavior handleBehavior
+		)
+		{
+			var handlerType = typeof(GetUsersQuery);
+
+			_handleBehavior = handleBehavior;
+
+		}
+
+		public async global::System.Threading.Tasks.ValueTask<int> HandleAsync(
+			global::Dummy.GetUsersQuery.Query request,
+			global::System.Threading.CancellationToken cancellationToken = default
+		)
+		{
+			return await _handleBehavior
+				.HandleAsync(request, cancellationToken)
+				.ConfigureAwait(false);
+		}
+	}
+
+	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+	public sealed class HandleBehavior : global::Immediate.Handlers.Shared.Behavior<global::Dummy.GetUsersQuery.Query, int>
+	{
+
+		public HandleBehavior(
+		)
+		{
+		}
+
+		public override async global::System.Threading.Tasks.ValueTask<int> HandleAsync(
+			global::Dummy.GetUsersQuery.Query request,
+			global::System.Threading.CancellationToken cancellationToken
+		)
+		{
+			return await global::Dummy.GetUsersQuery
+				.Handle(
+					request
+					, cancellationToken
+				)
+				.ConfigureAwait(false);
+		}
+	}
+
+	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+	public static IServiceCollection AddHandlers(
+		IServiceCollection services,
+		ServiceLifetime lifetime = ServiceLifetime.Scoped
+	)
+	{
+		services.Add(new(typeof(global::Dummy.GetUsersQuery.Handler), typeof(global::Dummy.GetUsersQuery.Handler), lifetime));
+		services.Add(new(typeof(global::Immediate.Handlers.Shared.IHandler<global::Dummy.GetUsersQuery.Query, int>), typeof(global::Dummy.GetUsersQuery.Handler), lifetime));
+		services.Add(new(typeof(global::Dummy.GetUsersQuery.HandleBehavior), typeof(global::Dummy.GetUsersQuery.HandleBehavior), lifetime));
+		return services;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/RoutesBuilderNameTests.CustomRoutesBuilderNameTest#IH.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/RoutesBuilderNameTests.CustomRoutesBuilderNameTest#IH.ServiceCollectionExtensions.g.verified.cs
@@ -1,0 +1,25 @@
+﻿//HintName: IH.ServiceCollectionExtensions.g.cs
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+#pragma warning disable CS1591
+
+public static class HandlerServiceCollectionExtensions
+{
+	public static IServiceCollection AddTestsBehaviors(
+		this IServiceCollection services)
+	{
+		
+		return services;
+	}
+
+	public static IServiceCollection AddTestsHandlers(
+		this IServiceCollection services,
+		ServiceLifetime lifetime = ServiceLifetime.Scoped
+	)
+	{
+		global::Dummy.GetUsersQuery.AddHandlers(services, lifetime);
+		
+		return services;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/RoutesBuilderNameTests.CustomRoutesBuilderNameTest#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/RoutesBuilderNameTests.CustomRoutesBuilderNameTest#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,47 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder
+{
+	public static partial class CustomRoutesBuilder
+	{
+		private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+		{
+			var endpoint = app
+				.MapGet(
+					"/test",
+					async (
+						[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+						[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+						CancellationToken token
+					) =>
+					{
+						var ret = await handler.HandleAsync(parameters, token);
+						return ret;
+					}
+				);
+
+		}
+	}
+}
+
+namespace Dummy
+{
+
+	/// <remarks><see cref="global::Dummy.GetUsersQuery.Query" /> registered using <c>[AsParameters]</c></remarks>
+	partial class GetUsersQuery
+	{
+		public static IReadOnlyList<string> Routes { get; } =
+		[
+			"/test",
+		];
+
+		public static string Route { get; } = "/test";
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/RoutesBuilderNameTests.CustomRoutesBuilderNameTest#RouteGroupBuilder..g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/RoutesBuilderNameTests.CustomRoutesBuilderNameTest#RouteGroupBuilder..g.verified.cs
@@ -1,0 +1,23 @@
+﻿//HintName: RouteGroupBuilder..g.cs
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using System.Diagnostics.CodeAnalysis;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class CustomRoutesBuilder
+{
+	public static RouteGroupBuilder MapCustomEndpoints(
+		this IEndpointRouteBuilder app,
+		[StringSyntax("Route")] string prefix = ""
+	)
+	{
+		var group = app.MapGroup(prefix);
+
+		MapDummy_GetUsersQueryEndpoint(group);
+
+		return group;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/RoutesBuilderNameTests.CustomRoutesBuilderNameWithRouteGroupTest#IH.Dummy.GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/RoutesBuilderNameTests.CustomRoutesBuilderNameWithRouteGroupTest#IH.Dummy.GetUsersQuery.g.verified.cs
@@ -1,0 +1,69 @@
+﻿//HintName: IH.Dummy.GetUsersQuery.g.cs
+using Microsoft.Extensions.DependencyInjection;
+
+#pragma warning disable CS1591
+
+namespace Dummy;
+
+partial class GetUsersQuery
+{
+	public sealed partial class Handler : global::Immediate.Handlers.Shared.IHandler<global::Dummy.GetUsersQuery.Query, int>
+	{
+		private readonly global::Dummy.GetUsersQuery.HandleBehavior _handleBehavior;
+
+		public Handler(
+			global::Dummy.GetUsersQuery.HandleBehavior handleBehavior
+		)
+		{
+			var handlerType = typeof(GetUsersQuery);
+
+			_handleBehavior = handleBehavior;
+
+		}
+
+		public async global::System.Threading.Tasks.ValueTask<int> HandleAsync(
+			global::Dummy.GetUsersQuery.Query request,
+			global::System.Threading.CancellationToken cancellationToken = default
+		)
+		{
+			return await _handleBehavior
+				.HandleAsync(request, cancellationToken)
+				.ConfigureAwait(false);
+		}
+	}
+
+	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+	public sealed class HandleBehavior : global::Immediate.Handlers.Shared.Behavior<global::Dummy.GetUsersQuery.Query, int>
+	{
+
+		public HandleBehavior(
+		)
+		{
+		}
+
+		public override async global::System.Threading.Tasks.ValueTask<int> HandleAsync(
+			global::Dummy.GetUsersQuery.Query request,
+			global::System.Threading.CancellationToken cancellationToken
+		)
+		{
+			return await global::Dummy.GetUsersQuery
+				.Handle(
+					request
+					, cancellationToken
+				)
+				.ConfigureAwait(false);
+		}
+	}
+
+	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+	public static IServiceCollection AddHandlers(
+		IServiceCollection services,
+		ServiceLifetime lifetime = ServiceLifetime.Scoped
+	)
+	{
+		services.Add(new(typeof(global::Dummy.GetUsersQuery.Handler), typeof(global::Dummy.GetUsersQuery.Handler), lifetime));
+		services.Add(new(typeof(global::Immediate.Handlers.Shared.IHandler<global::Dummy.GetUsersQuery.Query, int>), typeof(global::Dummy.GetUsersQuery.Handler), lifetime));
+		services.Add(new(typeof(global::Dummy.GetUsersQuery.HandleBehavior), typeof(global::Dummy.GetUsersQuery.HandleBehavior), lifetime));
+		return services;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/RoutesBuilderNameTests.CustomRoutesBuilderNameWithRouteGroupTest#IH.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/RoutesBuilderNameTests.CustomRoutesBuilderNameWithRouteGroupTest#IH.ServiceCollectionExtensions.g.verified.cs
@@ -1,0 +1,25 @@
+﻿//HintName: IH.ServiceCollectionExtensions.g.cs
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+#pragma warning disable CS1591
+
+public static class HandlerServiceCollectionExtensions
+{
+	public static IServiceCollection AddTestsBehaviors(
+		this IServiceCollection services)
+	{
+		
+		return services;
+	}
+
+	public static IServiceCollection AddTestsHandlers(
+		this IServiceCollection services,
+		ServiceLifetime lifetime = ServiceLifetime.Scoped
+	)
+	{
+		global::Dummy.GetUsersQuery.AddHandlers(services, lifetime);
+		
+		return services;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/RoutesBuilderNameTests.CustomRoutesBuilderNameWithRouteGroupTest#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/RoutesBuilderNameTests.CustomRoutesBuilderNameWithRouteGroupTest#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,47 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder
+{
+	public static partial class CustomRoutesBuilder
+	{
+		private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+		{
+			var endpoint = app
+				.MapGet(
+					"/test",
+					async (
+						[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+						[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+						CancellationToken token
+					) =>
+					{
+						var ret = await handler.HandleAsync(parameters, token);
+						return ret;
+					}
+				);
+
+		}
+	}
+}
+
+namespace Dummy
+{
+
+	/// <remarks><see cref="global::Dummy.GetUsersQuery.Query" /> registered using <c>[AsParameters]</c></remarks>
+	partial class GetUsersQuery
+	{
+		public static IReadOnlyList<string> Routes { get; } =
+		[
+			"/test",
+		];
+
+		public static string Route { get; } = "/test";
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/RoutesBuilderNameTests.CustomRoutesBuilderNameWithRouteGroupTest#RouteGroupBuilder.Admin.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/RoutesBuilderNameTests.CustomRoutesBuilderNameWithRouteGroupTest#RouteGroupBuilder.Admin.g.verified.cs
@@ -1,0 +1,23 @@
+﻿//HintName: RouteGroupBuilder.Admin.g.cs
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using System.Diagnostics.CodeAnalysis;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class CustomRoutesBuilder
+{
+	public static RouteGroupBuilder MapCustomAdminEndpoints(
+		this IEndpointRouteBuilder app,
+		[StringSyntax("Route")] string prefix = ""
+	)
+	{
+		var group = app.MapGroup(prefix);
+
+		MapDummy_GetUsersQueryEndpoint(group);
+
+		return group;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/RoutesBuilderNameTests.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/RoutesBuilderNameTests.cs
@@ -1,0 +1,91 @@
+namespace Immediate.Apis.Tests.GeneratorTests;
+
+public sealed class RoutesBuilderNameTests
+{
+	[Fact]
+	public async Task CustomRoutesBuilderNameTest()
+	{
+		var result = GeneratorTestHelper.RunGenerator(
+			"""
+			using System.Threading;
+			using System.Threading.Tasks;
+			using Immediate.Apis.Shared;
+			using Immediate.Handlers.Shared;
+
+			[assembly: RoutesBuilderName("Custom")]
+
+			namespace Dummy;
+
+			[Handler]
+			[MapGet("/test")]
+			public static partial class GetUsersQuery
+			{
+				public record Query;
+
+				private static ValueTask<int> Handle(
+					Query _,
+					CancellationToken token)
+				{
+					return ValueTask.FromResult(0);
+				}
+			}
+			"""
+		);
+
+		Assert.Equal(
+			[
+				@"Immediate.Apis.Generators/Immediate.Apis.Generators.ImmediateApisGenerator/RouteBuilder.Dummy_GetUsersQuery.g.cs",
+				@"Immediate.Apis.Generators/Immediate.Apis.Generators.ImmediateApisGenerator/RouteGroupBuilder..g.cs",
+				@"Immediate.Handlers.Generators/Immediate.Handlers.Generators.ImmediateHandlersGenerator/IH.Dummy.GetUsersQuery.g.cs",
+				@"Immediate.Handlers.Generators/Immediate.Handlers.Generators.ImmediateHandlersGenerator/IH.ServiceCollectionExtensions.g.cs",
+			],
+			result.GeneratedTrees.Select(t => t.FilePath.Replace('\\', '/'))
+		);
+
+		_ = await Verify(result);
+	}
+
+	[Fact]
+	public async Task CustomRoutesBuilderNameWithRouteGroupTest()
+	{
+		var result = GeneratorTestHelper.RunGenerator(
+			"""
+			using System.Threading;
+			using System.Threading.Tasks;
+			using Immediate.Apis.Shared;
+			using Immediate.Handlers.Shared;
+
+			[assembly: RoutesBuilderName("Custom")]
+
+			namespace Dummy;
+
+			[Handler]
+			[MapGet("/test")]
+			[RouteGroup("Admin")]
+			public static partial class GetUsersQuery
+			{
+				public record Query;
+
+				private static ValueTask<int> Handle(
+					Query _,
+					CancellationToken token)
+				{
+					return ValueTask.FromResult(0);
+				}
+			}
+			"""
+		);
+
+		Assert.Equal(
+			[
+				@"Immediate.Apis.Generators/Immediate.Apis.Generators.ImmediateApisGenerator/RouteBuilder.Dummy_GetUsersQuery.g.cs",
+				@"Immediate.Apis.Generators/Immediate.Apis.Generators.ImmediateApisGenerator/RouteGroupBuilder.Admin.g.cs",
+				@"Immediate.Handlers.Generators/Immediate.Handlers.Generators.ImmediateHandlersGenerator/IH.Dummy.GetUsersQuery.g.cs",
+				@"Immediate.Handlers.Generators/Immediate.Handlers.Generators.ImmediateHandlersGenerator/IH.ServiceCollectionExtensions.g.cs",
+			],
+			result.GeneratedTrees.Select(t => t.FilePath.Replace('\\', '/'))
+		);
+
+		_ = await Verify(result);
+	}
+}

--- a/tests/Immediate.Apis.Tests/Utility.cs
+++ b/tests/Immediate.Apis.Tests/Utility.cs
@@ -90,4 +90,20 @@ internal static class Utility
 			"Test@Group",
 			"Test#Group",
 		];
+
+	public static TheoryData<string> ValidRoutesBuilderNames =>
+		[
+			"_Test",
+			"Test_Name",
+			"Test123",
+		];
+
+	public static TheoryData<string> InvalidRoutesBuilderNames =>
+		[
+			"",
+			"123Test",
+			"Test.Name",
+			"Test Name",
+			"Test@Name",
+		];
 }


### PR DESCRIPTION
## Summary

Reference implementation for #281. Adds an opt-in, assembly-level attribute that overrides the assembly-derived name used for the generated routes builder.

```csharp
[assembly: Immediate.Apis.Shared.RoutesBuilderName("Custom")]
```

→ `CustomRoutesBuilder`, `app.MapCustomEndpoints()`, `app.MapCustomAdminEndpoints()` (for a `[RouteGroup("Admin")]`), instead of the assembly-name-derived defaults.

## What's included

- `RoutesBuilderNameAttribute` in `Immediate.Apis.Shared` (assembly-targeted).
- `ImmediateApisGenerator` reads it from `compilation.Assembly.GetAttributes()` (via the existing `IsImmediateApisShared` matcher), falling back to the assembly name when absent or invalid.
- `InvalidRoutesBuilderNameAnalyzer` (`IAPI0011`): the name must be a valid C# identifier (stricter than route-group names, which only need identifier-*part* chars, since this token starts the `{X}RoutesBuilder` class identifier). On an invalid value the generator falls back to the assembly name so emitted code still compiles, mirroring the route-group handling.
- readme docs, generator + analyzer tests, and verified snapshots.

## Backward compatibility

Fully backward-compatible — absent attribute produces byte-for-byte identical output (no existing snapshot changed).

## Open for maintainer direction (draft)

Marked **draft** because the **scope and attribute name are open** — see the discussion in #281. In particular, consuming the generated code is two halves that derive the same token independently (`AddXHandlers` from Immediate.Handlers + `MapXEndpoints` from Immediate.Apis), so an Apis-only override can desync them. This PR implements the library-scoped option as a concrete example; happy to rework it toward a shared attribute (e.g. in `Immediate.Handlers.Shared`) and a generator-neutral name if preferred.
