### PR TITLE
Support adding `TransformResult` for `ValueTask` endpoints

### DIFF
--- a/src/Immediate.Apis.CodeFixes/MissingTransformResultMethodCodeFixProvider.cs
+++ b/src/Immediate.Apis.CodeFixes/MissingTransformResultMethodCodeFixProvider.cs
@@ -69,16 +69,25 @@ public sealed class MissingTransformResultMethodCodeFixProvider : CodeFixProvide
 			return document;
 		}
 
-		if (handleMethodSyntax.ReturnType is not GenericNameSyntax
+		var (valid, returnType) = handleMethodSyntax.ReturnType switch
+		{
+			GenericNameSyntax
 			{
-				TypeArgumentList.Arguments: [{ } returnType],
-			})
+				TypeArgumentList.Arguments: [{ } rt],
+			} => (true, rt),
+
+			IdentifierNameSyntax => (true, null),
+
+			_ => (false, null),
+		};
+
+		if (!valid)
 		{
 			return document;
 		}
 
 		var transformResultMethodSyntax = MethodDeclaration(
-				returnType,
+				returnType ?? ParseTypeName("object"),
 				Identifier("TransformResult"))
 			.WithModifiers(
 				TokenList(
@@ -88,15 +97,33 @@ public sealed class MissingTransformResultMethodCodeFixProvider : CodeFixProvide
 				]))
 			.WithParameterList(
 				ParameterList(
-					SingletonSeparatedList(
-						Parameter(
-								Identifier("result"))
-							.WithType(returnType))))
+					returnType switch
+					{
+						{ } =>
+							SingletonSeparatedList(
+								Parameter(
+									Identifier("result")
+								)
+								.WithType(returnType)
+							),
+
+						_ => [],
+					}
+				)
+			)
 			.WithBody(
 				Block(
 					SingletonList<StatementSyntax>(
 						ReturnStatement(
-							IdentifierName("result")))))
+							returnType switch
+							{
+								{ } => IdentifierName("result"),
+								_ => ParseExpression("new()"),
+							}
+						)
+					)
+				)
+			)
 			.WithAdditionalAnnotations(Formatter.Annotation);
 
 		// Manually add trailing trivia to ensure proper spacing

--- a/src/Immediate.Apis.Generators/ImmediateApisGenerator.Transform.cs
+++ b/src/Immediate.Apis.Generators/ImmediateApisGenerator.Transform.cs
@@ -234,7 +234,7 @@ public sealed partial class ImmediateApisGenerator
 						Parameters: [],
 					}
 				)
-				);
+		);
 	}
 
 	private static EquatableReadOnlyList<Class> GetOuterClasses(INamedTypeSymbol symbol)

--- a/tests/Immediate.Apis.Tests/CodeFixTests/MissingTransformResultMethodCodeFixTests.cs
+++ b/tests/Immediate.Apis.Tests/CodeFixTests/MissingTransformResultMethodCodeFixTests.cs
@@ -130,4 +130,64 @@ public sealed class MissingTransformResultMethodCodeFixTests
 				"""
 			).RunAsync(TestContext.Current.CancellationToken);
 	}
+
+	[Theory]
+	[MemberData(nameof(Utility.Methods), MemberType = typeof(Utility))]
+	public async Task ValidDefinitionHandleAsyncWithNoReturnType_ShouldAddTransformResultMethod(string method)
+	{
+		await CodeFixTestHelper
+			.CreateCodeFixTest<MissingTransformResultMethodAnalyzer, MissingTransformResultMethodCodeFixProvider>(
+				$$"""
+				using System.Threading;
+				using System.Threading.Tasks;
+				using Immediate.Apis.Shared;
+				using Immediate.Handlers.Shared;
+				using System.Collections.Generic;
+
+				namespace Dummy;
+
+				[Handler]
+				[Map{{method}}("/test")]
+				public static class {|IAPI0007:GetUsersQuery|}
+				{
+					public record Query;
+					public record Response;
+				
+					private static async ValueTask HandleAsync(
+						Query _,
+						CancellationToken token)
+					{
+					}
+				}
+				""",
+				$$"""
+				using System.Threading;
+				using System.Threading.Tasks;
+				using Immediate.Apis.Shared;
+				using Immediate.Handlers.Shared;
+				using System.Collections.Generic;
+
+				namespace Dummy;
+
+				[Handler]
+				[Map{{method}}("/test")]
+				public static class GetUsersQuery
+				{
+					internal static object TransformResult()
+					{
+						return new();
+					}
+
+					public record Query;
+					public record Response;
+				
+					private static async ValueTask HandleAsync(
+						Query _,
+						CancellationToken token)
+					{
+					}
+				}
+				"""
+			).RunAsync(TestContext.Current.CancellationToken);
+	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic code fixes for handlers that return either a typed or non-typed asynchronous result.
  * Generated `TransformResult` methods now use the appropriate result parameter when available, or create a new result when no type is specified.
* **Tests**
  * Added coverage for handlers with non-generic asynchronous return types.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->