### PR TITLE
Add namespace to `MapXxxEndpoints`

### DIFF
--- a/src/Immediate.Apis.Generators/ImmediateApisGenerator.Render.cs
+++ b/src/Immediate.Apis.Generators/ImmediateApisGenerator.Render.cs
@@ -30,6 +30,7 @@ public sealed partial class ImmediateApisGenerator
 		EquatableReadOnlyList<RouteEndpoint> endpoints,
 		EquatableReadOnlyList<RouteGroupDefinition> groups,
 		AssemblyDefaults assemblyDefaults,
+		string @namespace,
 		Template template
 	)
 	{
@@ -54,6 +55,7 @@ public sealed partial class ImmediateApisGenerator
 		{
 			assemblyDefaults.AssemblyName,
 			assemblyDefaults.LanguageVersion,
+			Namespace = @namespace,
 
 			Tags = tags,
 			Version = ThisAssembly.InformationalVersion,

--- a/src/Immediate.Apis.Generators/ImmediateApisGenerator.cs
+++ b/src/Immediate.Apis.Generators/ImmediateApisGenerator.cs
@@ -26,6 +26,15 @@ public sealed partial class ImmediateApisGenerator : IIncrementalGenerator
 			})
 			.WithTrackingName("AssemblyName");
 
+		var @namespace = context
+			.AnalyzerConfigOptionsProvider
+			.Select(
+				(c, _) => c.GlobalOptions
+					.TryGetValue("build_property.rootnamespace", out var ns)
+						? ns : ""
+			)
+			.WithTrackingName("RootNamespace");
+
 		var perMethodTemplate = Utility.GetTemplate("Route");
 		context.RegisterSourceOutput(
 			endpoints,
@@ -53,8 +62,8 @@ public sealed partial class ImmediateApisGenerator : IIncrementalGenerator
 		context.RegisterSourceOutput(
 			routesByGroup.Select((g, _) => g.GetValueOrDefault(ValueTuple.Create<string?>(item1: null)))
 				.Combine(routeGroupsByGroup.Select((g, _) => g.GetValueOrDefault(ValueTuple.Create<string?>(item1: null))))
-				.Combine(assemblyDefaults),
-			(spc, m) => RenderMapEndpoints(spc, m.Left.Left, m.Left.Right, m.Right, mapEndpointsTemplate)
+				.Combine(assemblyDefaults.Combine(@namespace)),
+			(spc, m) => RenderMapEndpoints(spc, m.Left.Left, m.Left.Right, m.Right.Left, m.Right.Right, mapEndpointsTemplate)
 		);
 
 		var routeGroups = routesByGroup.Combine(routeGroupsByGroup)

--- a/tests/Immediate.Apis.Tests/GeneratorTests/GeneratorTestHelper.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/GeneratorTestHelper.cs
@@ -4,6 +4,7 @@ using Immediate.Apis.Generators;
 using Immediate.Handlers.Generators;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Immediate.Apis.Tests.GeneratorTests;
 
@@ -42,6 +43,7 @@ public static class GeneratorTestHelper
 				new ImmediateHandlersGenerator().AsSourceGenerator(),
 			],
 			parseOptions: options,
+			optionsProvider: new OptionsProvider(),
 			driverOptions: new GeneratorDriverOptions(default, trackIncrementalGeneratorSteps: true)
 		);
 
@@ -148,5 +150,26 @@ public static class GeneratorTestHelper
 		var outputs = steps.SelectMany(o => o.Outputs);
 
 		Assert.All(outputs, o => Assert.True(o.Reason is IncrementalStepRunReason.Unchanged or IncrementalStepRunReason.Cached));
+	}
+
+	private sealed class OptionsProvider : AnalyzerConfigOptionsProvider
+	{
+		private static readonly AnalyzerConfigOptions s_options =
+			new DictionaryAnalyzerOptions(
+				new(StringComparer.OrdinalIgnoreCase)
+				{
+					["build_property.rootnamespace"] = "Immediate.Apis.Testing",
+				}
+			);
+
+		public override AnalyzerConfigOptions GetOptions(SyntaxTree tree) => s_options;
+		public override AnalyzerConfigOptions GetOptions(AdditionalText textFile) => s_options;
+		public override AnalyzerConfigOptions GlobalOptions => s_options;
+	}
+
+	private sealed class DictionaryAnalyzerOptions(Dictionary<string, string> properties) : AnalyzerConfigOptions
+	{
+		public override bool TryGetValue(string key, out string value)
+			=> properties.TryGetValue(key, out value!);
 	}
 }

--- a/tests/Immediate.Apis.Tests/GeneratorTests/GeneratorTestHelper.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/GeneratorTestHelper.cs
@@ -135,6 +135,7 @@ public static class GeneratorTestHelper
 		new string[]
 		{
 			"AssemblyName",
+			"RootNamespace",
 			"Endpoints",
 			"EndpointsDictionary",
 			"RouteGroupsDictionary",

--- a/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/MapEndpointsTests.ValidAddServicesMethod_framework=net10.0#IA.MapEndpoints.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/MapEndpointsTests.ValidAddServicesMethod_framework=net10.0#IA.MapEndpoints.g.verified.cs
@@ -4,6 +4,8 @@
 
 #pragma warning disable CS1591
 
+namespace Immediate.Apis.Testing;
+
 public static partial class ApisServiceCollectionExtensions
 {
 	public static global::Microsoft.AspNetCore.Routing.RouteGroupBuilder MapTestsEndpoints(

--- a/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/MapEndpointsTests.ValidAddServicesMethod_framework=net10.0#IH.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/MapEndpointsTests.ValidAddServicesMethod_framework=net10.0#IH.ServiceCollectionExtensions.g.verified.cs
@@ -4,6 +4,8 @@
 
 #pragma warning disable CS1591
 
+namespace Immediate.Apis.Testing;
+
 public static class HandlerServiceCollectionExtensions
 {
 	public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddTestsBehaviors(

--- a/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/MapEndpointsTests.ValidAddServicesMethod_framework=net11.0#IA.MapEndpoints.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/MapEndpointsTests.ValidAddServicesMethod_framework=net11.0#IA.MapEndpoints.g.verified.cs
@@ -4,6 +4,8 @@
 
 #pragma warning disable CS1591
 
+namespace Immediate.Apis.Testing;
+
 public static partial class ApisServiceCollectionExtensions
 {
 	public static global::Microsoft.AspNetCore.Routing.RouteGroupBuilder MapTestsEndpoints(

--- a/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/MapEndpointsTests.ValidAddServicesMethod_framework=net11.0#IH.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/MapEndpointsTests.ValidAddServicesMethod_framework=net11.0#IH.ServiceCollectionExtensions.g.verified.cs
@@ -4,6 +4,8 @@
 
 #pragma warning disable CS1591
 
+namespace Immediate.Apis.Testing;
+
 public static class HandlerServiceCollectionExtensions
 {
 	public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddTestsBehaviors(

--- a/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/MapEndpointsTests.ValidAddServicesMethod_framework=net8.0#IA.MapEndpoints.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/MapEndpointsTests.ValidAddServicesMethod_framework=net8.0#IA.MapEndpoints.g.verified.cs
@@ -4,6 +4,8 @@
 
 #pragma warning disable CS1591
 
+namespace Immediate.Apis.Testing;
+
 public static partial class ApisServiceCollectionExtensions
 {
 	public static global::Microsoft.AspNetCore.Routing.RouteGroupBuilder MapTestsEndpoints(

--- a/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/MapEndpointsTests.ValidAddServicesMethod_framework=net8.0#IH.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/MapEndpointsTests.ValidAddServicesMethod_framework=net8.0#IH.ServiceCollectionExtensions.g.verified.cs
@@ -4,6 +4,8 @@
 
 #pragma warning disable CS1591
 
+namespace Immediate.Apis.Testing;
+
 public static class HandlerServiceCollectionExtensions
 {
 	public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddTestsBehaviors(

--- a/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/MapEndpointsTests.ValidAddServicesMethod_framework=net9.0#IA.MapEndpoints.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/MapEndpointsTests.ValidAddServicesMethod_framework=net9.0#IA.MapEndpoints.g.verified.cs
@@ -4,6 +4,8 @@
 
 #pragma warning disable CS1591
 
+namespace Immediate.Apis.Testing;
+
 public static partial class ApisServiceCollectionExtensions
 {
 	public static global::Microsoft.AspNetCore.Routing.RouteGroupBuilder MapTestsEndpoints(

--- a/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/MapEndpointsTests.ValidAddServicesMethod_framework=net9.0#IH.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/MapEndpointsTests.ValidAddServicesMethod_framework=net9.0#IH.ServiceCollectionExtensions.g.verified.cs
@@ -4,6 +4,8 @@
 
 #pragma warning disable CS1591
 
+namespace Immediate.Apis.Testing;
+
 public static class HandlerServiceCollectionExtensions
 {
 	public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddTestsBehaviors(

--- a/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/RouteGroupTests.TaggedRouteGroupTest_framework=net10.0#IA.MapEndpoints.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/RouteGroupTests.TaggedRouteGroupTest_framework=net10.0#IA.MapEndpoints.g.verified.cs
@@ -4,6 +4,8 @@
 
 #pragma warning disable CS1591
 
+namespace Immediate.Apis.Testing;
+
 public static partial class ApisServiceCollectionExtensions
 {
 	public static global::Microsoft.AspNetCore.Routing.RouteGroupBuilder MapTestsEndpoints(

--- a/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/RouteGroupTests.TaggedRouteGroupTest_framework=net10.0#IH.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/RouteGroupTests.TaggedRouteGroupTest_framework=net10.0#IH.ServiceCollectionExtensions.g.verified.cs
@@ -4,6 +4,8 @@
 
 #pragma warning disable CS1591
 
+namespace Immediate.Apis.Testing;
+
 public static class HandlerServiceCollectionExtensions
 {
 	public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddTestsBehaviors(

--- a/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/RouteGroupTests.TaggedRouteGroupTest_framework=net11.0#IA.MapEndpoints.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/RouteGroupTests.TaggedRouteGroupTest_framework=net11.0#IA.MapEndpoints.g.verified.cs
@@ -4,6 +4,8 @@
 
 #pragma warning disable CS1591
 
+namespace Immediate.Apis.Testing;
+
 public static partial class ApisServiceCollectionExtensions
 {
 	public static global::Microsoft.AspNetCore.Routing.RouteGroupBuilder MapTestsEndpoints(

--- a/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/RouteGroupTests.TaggedRouteGroupTest_framework=net11.0#IH.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/RouteGroupTests.TaggedRouteGroupTest_framework=net11.0#IH.ServiceCollectionExtensions.g.verified.cs
@@ -4,6 +4,8 @@
 
 #pragma warning disable CS1591
 
+namespace Immediate.Apis.Testing;
+
 public static class HandlerServiceCollectionExtensions
 {
 	public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddTestsBehaviors(

--- a/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/RouteGroupTests.TaggedRouteGroupTest_framework=net8.0#IA.MapEndpoints.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/RouteGroupTests.TaggedRouteGroupTest_framework=net8.0#IA.MapEndpoints.g.verified.cs
@@ -4,6 +4,8 @@
 
 #pragma warning disable CS1591
 
+namespace Immediate.Apis.Testing;
+
 public static partial class ApisServiceCollectionExtensions
 {
 	public static global::Microsoft.AspNetCore.Routing.RouteGroupBuilder MapTestsEndpoints(

--- a/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/RouteGroupTests.TaggedRouteGroupTest_framework=net8.0#IH.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/RouteGroupTests.TaggedRouteGroupTest_framework=net8.0#IH.ServiceCollectionExtensions.g.verified.cs
@@ -4,6 +4,8 @@
 
 #pragma warning disable CS1591
 
+namespace Immediate.Apis.Testing;
+
 public static class HandlerServiceCollectionExtensions
 {
 	public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddTestsBehaviors(

--- a/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/RouteGroupTests.TaggedRouteGroupTest_framework=net9.0#IA.MapEndpoints.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/RouteGroupTests.TaggedRouteGroupTest_framework=net9.0#IA.MapEndpoints.g.verified.cs
@@ -4,6 +4,8 @@
 
 #pragma warning disable CS1591
 
+namespace Immediate.Apis.Testing;
+
 public static partial class ApisServiceCollectionExtensions
 {
 	public static global::Microsoft.AspNetCore.Routing.RouteGroupBuilder MapTestsEndpoints(

--- a/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/RouteGroupTests.TaggedRouteGroupTest_framework=net9.0#IH.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/RouteGroupTests.TaggedRouteGroupTest_framework=net9.0#IH.ServiceCollectionExtensions.g.verified.cs
@@ -4,6 +4,8 @@
 
 #pragma warning disable CS1591
 
+namespace Immediate.Apis.Testing;
+
 public static class HandlerServiceCollectionExtensions
 {
 	public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddTestsBehaviors(

--- a/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/SimpleApiTests.MapMethodTagsTest_framework=net10.0#IA.MapEndpoints.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/SimpleApiTests.MapMethodTagsTest_framework=net10.0#IA.MapEndpoints.g.verified.cs
@@ -4,6 +4,8 @@
 
 #pragma warning disable CS1591
 
+namespace Immediate.Apis.Testing;
+
 public static partial class ApisServiceCollectionExtensions
 {
 	public static global::Microsoft.AspNetCore.Routing.RouteGroupBuilder MapTestsEndpoints(

--- a/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/SimpleApiTests.MapMethodTagsTest_framework=net10.0#IH.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/SimpleApiTests.MapMethodTagsTest_framework=net10.0#IH.ServiceCollectionExtensions.g.verified.cs
@@ -4,6 +4,8 @@
 
 #pragma warning disable CS1591
 
+namespace Immediate.Apis.Testing;
+
 public static class HandlerServiceCollectionExtensions
 {
 	public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddTestsBehaviors(

--- a/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/SimpleApiTests.MapMethodTagsTest_framework=net11.0#IA.MapEndpoints.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/SimpleApiTests.MapMethodTagsTest_framework=net11.0#IA.MapEndpoints.g.verified.cs
@@ -4,6 +4,8 @@
 
 #pragma warning disable CS1591
 
+namespace Immediate.Apis.Testing;
+
 public static partial class ApisServiceCollectionExtensions
 {
 	public static global::Microsoft.AspNetCore.Routing.RouteGroupBuilder MapTestsEndpoints(

--- a/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/SimpleApiTests.MapMethodTagsTest_framework=net11.0#IH.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/SimpleApiTests.MapMethodTagsTest_framework=net11.0#IH.ServiceCollectionExtensions.g.verified.cs
@@ -4,6 +4,8 @@
 
 #pragma warning disable CS1591
 
+namespace Immediate.Apis.Testing;
+
 public static class HandlerServiceCollectionExtensions
 {
 	public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddTestsBehaviors(

--- a/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/SimpleApiTests.MapMethodTagsTest_framework=net8.0#IA.MapEndpoints.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/SimpleApiTests.MapMethodTagsTest_framework=net8.0#IA.MapEndpoints.g.verified.cs
@@ -4,6 +4,8 @@
 
 #pragma warning disable CS1591
 
+namespace Immediate.Apis.Testing;
+
 public static partial class ApisServiceCollectionExtensions
 {
 	public static global::Microsoft.AspNetCore.Routing.RouteGroupBuilder MapTestsEndpoints(

--- a/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/SimpleApiTests.MapMethodTagsTest_framework=net8.0#IH.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/SimpleApiTests.MapMethodTagsTest_framework=net8.0#IH.ServiceCollectionExtensions.g.verified.cs
@@ -4,6 +4,8 @@
 
 #pragma warning disable CS1591
 
+namespace Immediate.Apis.Testing;
+
 public static class HandlerServiceCollectionExtensions
 {
 	public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddTestsBehaviors(

--- a/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/SimpleApiTests.MapMethodTagsTest_framework=net9.0#IA.MapEndpoints.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/SimpleApiTests.MapMethodTagsTest_framework=net9.0#IA.MapEndpoints.g.verified.cs
@@ -4,6 +4,8 @@
 
 #pragma warning disable CS1591
 
+namespace Immediate.Apis.Testing;
+
 public static partial class ApisServiceCollectionExtensions
 {
 	public static global::Microsoft.AspNetCore.Routing.RouteGroupBuilder MapTestsEndpoints(

--- a/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/SimpleApiTests.MapMethodTagsTest_framework=net9.0#IH.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/Snapshots/SimpleApiTests.MapMethodTagsTest_framework=net9.0#IH.ServiceCollectionExtensions.g.verified.cs
@@ -4,6 +4,8 @@
 
 #pragma warning disable CS1591
 
+namespace Immediate.Apis.Testing;
+
 public static class HandlerServiceCollectionExtensions
 {
 	public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddTestsBehaviors(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Generated API endpoints and service extensions now use the project’s configured root namespace automatically.
  - Generated code is placed in the appropriate namespace, improving integration with existing application code.

- **Bug Fixes**
  - Prevented generated types from unintentionally appearing in the global namespace.

- **Tests**
  - Updated generator validation across supported framework versions to verify namespace-aware output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->